### PR TITLE
Sign request only with the body content + resolve userID for API key based session

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.12.x
+  - 1.15.x
 addons:
   apt:
     packages:

--- a/bunq/bunq_test.go
+++ b/bunq/bunq_test.go
@@ -17,8 +17,6 @@ import (
 	"os"
 	"sync"
 	"testing"
-
-	uuid "github.com/satori/go.uuid"
 )
 
 const errorRequestToUnMockedHTTPMethod = "request made to an un mocked http method. url: %q method: %q"
@@ -198,9 +196,6 @@ func formatFilePathByName(fileName string) string {
 }
 
 func sendResponseWithSignature(t *testing.T, w http.ResponseWriter, resCode int, body interface{}) {
-	w.Header().Set("X-Bunq-Client-Response-Id", uuid.NewV4().String())
-	w.Header().Set("Cache-controll", fmt.Sprintf("max-age=%s", uuid.NewV4().String()))
-
 	b, _ := json.Marshal(body)
 	stringToSign := fmt.Sprintf("%s", b)
 

--- a/bunq/bunq_test.go
+++ b/bunq/bunq_test.go
@@ -18,7 +18,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 const errorRequestToUnMockedHTTPMethod = "request made to an un mocked http method. url: %q method: %q"
@@ -200,12 +200,9 @@ func formatFilePathByName(fileName string) string {
 func sendResponseWithSignature(t *testing.T, w http.ResponseWriter, resCode int, body interface{}) {
 	w.Header().Set("X-Bunq-Client-Response-Id", uuid.NewV4().String())
 	w.Header().Set("Cache-controll", fmt.Sprintf("max-age=%s", uuid.NewV4().String()))
-	stringToSign := fmt.Sprintf("%d\n", resCode)
-	stringToSign += getAllHeaderToSignAsString(w.Header(), false)
 
 	b, _ := json.Marshal(body)
-
-	stringToSign += fmt.Sprintf("\n%s", b)
+	stringToSign := fmt.Sprintf("%s", b)
 
 	h := sha256.New()
 	_, _ = h.Write([]byte(stringToSign))

--- a/bunq/client.go
+++ b/bunq/client.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 const (
@@ -62,9 +62,9 @@ type Client struct {
 	*http.Client
 	ctx context.Context
 
-	baseURL string
-	apiKey  string
-	Debug   bool
+	baseURL     string
+	apiKey      string
+	Debug       bool
 	description string
 
 	Err error
@@ -537,6 +537,8 @@ func (c *Client) GetUserID() (int, error) {
 		return c.sessionServerContext.UserPerson.ID, nil
 	} else if c.isUserCompany {
 		return c.sessionServerContext.UserCompany.ID, nil
+	} else if c.isUserAPIkey {
+		return c.sessionServerContext.UserAPIKey.ID, nil
 	}
 
 	return 0, fmt.Errorf("bunq: could not determine user id")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/OGKevin/go-bunq
 
-go 1.12
+go 1.15
 
 require (
 	github.com/kr/pretty v0.1.0 // indirect


### PR DESCRIPTION
Signing of full API request is deprecated, only the body should be used: https://beta.doc.bunq.com/basics/authentication/signing