### PR TITLE
update customer struct to match changed datatype in bunq api

### DIFF
--- a/bunq/data.go
+++ b/bunq/data.go
@@ -157,7 +157,7 @@ type cardLimits struct {
 }
 
 type customer struct {
-	BillingAccountID              string `json:"billing_account_id"`
+	BillingAccountID              int    `json:"billing_account_id"`
 	InvoiceNotificationPreference string `json:"invoice_notification_preference"`
 	ID                            int    `json:"id"`
 	Created                       string `json:"created"`


### PR DESCRIPTION
Despite Bunq's API docs saying that this field should be `text`, it is definitely coming back as a number in the response.